### PR TITLE
Backfill missing lab metadata (9 files)

### DIFF
--- a/Instructions/Labs/00-Sales-trial.md
+++ b/Instructions/Labs/00-Sales-trial.md
@@ -1,6 +1,19 @@
 ---
 lab:
-    title: 'Lab 0: Validate lab environment'
+  title: 'Lab 0: Validate lab environment'
+  description: Contoso Coffee produces high-quality coffee and coffee machines, which
+    they retail through channels including new Contoso Retail Stores in premium locations,
+    premium food resellers and the Contoso Coffee Web Site. Contoso Coffee is looking
+    to formalize their sales process to increase revenue and give leadership, stronger
+    forecasting abilities. You are a functional consultant configuring Dynamics 365
+    for Sales for Contoso Coffee. In this lab, you will install the Sales application
+    and install sample data. This new offering will help them to build direct relationship
+    with their customers and learn more about how customers consume their products.
+  duration: 36 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Dynamics 365
 ---
 
 # Module 1: Configure Dynamics 365 Sales

--- a/Instructions/Labs/01-1-Configure-supporting-apps.md
+++ b/Instructions/Labs/01-1-Configure-supporting-apps.md
@@ -1,6 +1,15 @@
 ---
 lab:
-    title: 'Lab 1.1: Configure supporting applications'
+  title: 'Lab 1.1: Configure supporting applications'
+  description: 'Contoso Coffee sellers report that although Dynamics 365 Sales is
+    very helpful in increasing seller productivity, the application feels very siloed
+    in relation to their daily flow of work. They have the following requirements
+    for their IT department:'
+  duration: 126 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Dynamics 365
 ---
 
 # Module 1: Configure Dynamics 365 Sales

--- a/Instructions/Labs/02-Manage-leads-opp.md
+++ b/Instructions/Labs/02-Manage-leads-opp.md
@@ -1,6 +1,16 @@
 ---
 lab:
-    title: 'Lab 2.1: Manage leads and opportunities'
+  title: 'Lab 2.1: Manage leads and opportunities'
+  description: Contoso Coffee is looking to use Dynamics 365 Sales to formalize their
+    sales process as well as address a backlog of untouched leads imported by the
+    marketing team from trade shows and campaigns. As a sales analyst at Contoso Coffee,
+    you have been asked to assess and update lead records to ensure that the executive
+    team is working from an accurate pipeline report in the upcoming leadership meeting.
+  duration: 152 minutes
+  level: 200
+  islab: true
+  primarytopics:
+  - Dynamics 365
 ---
 
 # Module 2: Manage leads and opportunities with Dynamics 365 Sales

--- a/Instructions/Labs/03-1-Product-catalog.md
+++ b/Instructions/Labs/03-1-Product-catalog.md
@@ -1,6 +1,16 @@
 ---
 lab:
-    title: 'Lab 3.1: Configure the product catalog'
+  title: 'Lab 3.1: Configure the product catalog'
+  description: As Contoso Coffee grows, they are looking to standardize their pricing
+    structure and allow for easier creation of quotes, orders, and invoices with more
+    accurate pricing and product details. Contoso Coffee recently released its newest
+    smart coffee machine. As a functional consultant on their Dynamics 365 Sales implementation,
+    you have been asked to configure the product catalog.
+  duration: 126 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Dynamics 365
 ---
 
 # Module 3: Manage orders and product catalog with Dynamics 365

--- a/Instructions/Labs/03-2-Quotes.md
+++ b/Instructions/Labs/03-2-Quotes.md
@@ -1,6 +1,16 @@
 ---
 lab:
-    title: 'Lab 3.2: Build quotes'
+  title: 'Lab 3.2: Build quotes'
+  description: As a sales analyst for the Dynamics 365 Sales implementation at Contoso
+    Coffee, you want to ensure that salespeople will be able to leverage the product
+    catalog enhancements throughout the entire sales lifecycle. To ensure the functionality
+    is working correctly, you will test the process of building a quote from a new
+    opportunity.
+  duration: 76 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Dynamics 365
 ---
 
 # Module 3: Manage orders and product catalog with Dynamics 365

--- a/Instructions/Labs/03-3-Orders-and-invoices.md
+++ b/Instructions/Labs/03-3-Orders-and-invoices.md
@@ -1,6 +1,15 @@
 ---
 lab:
-    title: 'Lab 3.3: Orders and invoices'
+  title: 'Lab 3.3: Orders and invoices'
+  description: As a sales analyst for the Dynamics 365 Sales implementation at Contoso
+    Coffee, you want to ensure that salespeople will be able to leverage the product
+    catalog enhancements throughout the entire sales lifecycle. To ensure the functionality
+    is working correctly, you will test the process of generating orders, and invoices.
+  duration: 54 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Dynamics 365
 ---
 
 # Module 3: Manage orders and product catalog with Dynamics 365

--- a/Instructions/Labs/05-1-Business-process-flow.md
+++ b/Instructions/Labs/05-1-Business-process-flow.md
@@ -1,6 +1,13 @@
 ---
 lab:
-    title: 'Lab 5.1: Customize a business process flow'
+  title: 'Lab 5.1: Customize a business process flow'
+  description: Contoso Coffee is looking to add a few extra steps to their tried-and-true
+    Sales Business Process. Although sellers have been successful following this framework
+    in the past, they are reporting that a few new suggestions would help nurture
+    leads and land high-value contracts.
+  duration: 134 minutes
+  level: 100
+  islab: true
 ---
 
 # Module 5: Work with Dynamics 365 Sales Insights and the Sales accelerator 

--- a/Instructions/Labs/05-2-Sequences.md
+++ b/Instructions/Labs/05-2-Sequences.md
@@ -1,6 +1,16 @@
 ---
 lab:
-    title: 'Lab 5.2: Build a sequence'
+  title: 'Lab 5.2: Build a sequence'
+  description: Contoso Coffee’s sellers suggest that sales could be improved if organizational
+    "best practices" were easier to follow. After examination, Contoso’s sales managers
+    have determined an ideal sequence of sales events for sellers. They want to enforce
+    best practices by setting up a series of consecutive activities for sellers to
+    follow while qualifying leads. You want to ensure that it is as easy as possible
+    for sellers to follow during their day. You have determined that a sequence is
+    the best way to accomplish this.
+  duration: 154 minutes
+  level: 100
+  islab: true
 ---
 
 # Module 5: Work with Dynamics 365 Sales Insights and the Sales accelerator 

--- a/Instructions/Labs/06-1-Dashboard.md
+++ b/Instructions/Labs/06-1-Dashboard.md
@@ -1,6 +1,15 @@
 ---
 lab:
-    title: 'Lab 6.1: Configure a dashboard'
+  title: 'Lab 6.1: Configure a dashboard'
+  description: Contoso Coffee’s sales managers want to monitor their sales team’s
+    success more effectively, especially around closed opportunities. One sales manager
+    has requested a personal dashboard that will provide them with an overview of
+    recently closed opportunities and their sellers' actions against them. Additionally,
+    they would like this dashboard to be their default dashboard when they open the
+    Dashboards section of the application.
+  duration: 52 minutes
+  level: 100
+  islab: true
 ---
 
 # Module 6: Analyze Dynamics 365 Sales data


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 9

- `Instructions/Labs/00-Sales-trial.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/01-1-Configure-supporting-apps.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/02-Manage-leads-opp.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/03-1-Product-catalog.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/03-2-Quotes.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/03-3-Orders-and-invoices.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/05-1-Business-process-flow.md` (description,duration,level,islab)
- `Instructions/Labs/05-2-Sequences.md` (description,duration,level,islab)
- `Instructions/Labs/06-1-Dashboard.md` (description,duration,level,islab)
