### PR TITLE
Backfill missing lab metadata (9 files)

### DIFF
--- a/Instructions/Labs/00-Sales-trial.md
+++ b/Instructions/Labs/00-Sales-trial.md
@@ -1,6 +1,12 @@
 ---
 lab:
-    title: 'Lab 0: Validate lab environment'
+  title: 'Lab 0: Validate lab environment'
+  description: Contoso Coffee produces high-quality coffee and coffee machines, which they retail through channels including new Contoso Retail Stores in premium locations, premium food resellers and the Contoso Coffee Web Site. Contoso Coffee is looking to formalize their sales process to increase revenue and give leadership, stronger forecasting abilities. You are a functional consultant configuring Dynamics 365 for Sales for Contoso Coffee. In this lab, you will install the Sales application and install sample data. This new offering will help them to build direct relationship with their customers and learn more about how customers consume their products.
+  duration: 36 minutes
+  level: 100
+  islab: true
+  primarytopics:
+    - Dynamics 365
 ---
 
 # Module 1: Configure Dynamics 365 Sales

--- a/Instructions/Labs/00-Sales-trial.md
+++ b/Instructions/Labs/00-Sales-trial.md
@@ -2,7 +2,7 @@
 lab:
   title: 'Lab 0: Validate lab environment'
   description: Contoso Coffee produces high-quality coffee and coffee machines, which they retail through channels including new Contoso Retail Stores in premium locations, premium food resellers and the Contoso Coffee Web Site. Contoso Coffee is looking to formalize their sales process to increase revenue and give leadership, stronger forecasting abilities. You are a functional consultant configuring Dynamics 365 for Sales for Contoso Coffee. In this lab, you will install the Sales application and install sample data. This new offering will help them to build direct relationship with their customers and learn more about how customers consume their products.
-  duration: 36 minutes
+  duration: 10 minutes
   level: 100
   islab: true
   primarytopics:

--- a/Instructions/Labs/01-1-Configure-supporting-apps.md
+++ b/Instructions/Labs/01-1-Configure-supporting-apps.md
@@ -1,6 +1,10 @@
 ---
 lab:
-    title: 'Lab 1.1: Configure supporting applications'
+  title: 'Lab 1.1: Configure supporting applications'
+  description: In this lab, we will turn on and configure the features that will help our CRM organization meet these sellers' requirements.
+  duration: 126 minutes
+  level: 100
+  islab: true
 ---
 
 # Module 1: Configure Dynamics 365 Sales

--- a/Instructions/Labs/01-1-Configure-supporting-apps.md
+++ b/Instructions/Labs/01-1-Configure-supporting-apps.md
@@ -2,7 +2,7 @@
 lab:
   title: 'Lab 1.1: Configure supporting applications'
   description: In this lab, we will turn on and configure the features that will help our CRM organization meet these sellers' requirements.
-  duration: 126 minutes
+  duration: 30 minutes
   level: 100
   islab: true
 ---

--- a/Instructions/Labs/02-Manage-leads-opp.md
+++ b/Instructions/Labs/02-Manage-leads-opp.md
@@ -1,6 +1,10 @@
 ---
 lab:
-    title: 'Lab 2.1: Manage leads and opportunities'
+  title: 'Lab 2.1: Manage leads and opportunities'
+  description: In this task, you will create three leads, one without company information and two with company information.
+  duration: 152 minutes
+  level: 200
+  islab: true
 ---
 
 # Module 2: Manage leads and opportunities with Dynamics 365 Sales

--- a/Instructions/Labs/02-Manage-leads-opp.md
+++ b/Instructions/Labs/02-Manage-leads-opp.md
@@ -2,7 +2,7 @@
 lab:
   title: 'Lab 2.1: Manage leads and opportunities'
   description: In this task, you will create three leads, one without company information and two with company information.
-  duration: 152 minutes
+  duration: 30 minutes
   level: 200
   islab: true
 ---

--- a/Instructions/Labs/03-1-Product-catalog.md
+++ b/Instructions/Labs/03-1-Product-catalog.md
@@ -2,7 +2,7 @@
 lab:
   title: 'Lab 3.1: Configure the product catalog'
   description: In this task, you will create a price list for the filters.
-  duration: 126 minutes
+  duration: 30 minutes
   level: 100
   islab: true
 ---

--- a/Instructions/Labs/03-1-Product-catalog.md
+++ b/Instructions/Labs/03-1-Product-catalog.md
@@ -1,6 +1,10 @@
 ---
 lab:
-    title: 'Lab 3.1: Configure the product catalog'
+  title: 'Lab 3.1: Configure the product catalog'
+  description: In this task, you will create a price list for the filters.
+  duration: 126 minutes
+  level: 100
+  islab: true
 ---
 
 # Module 3: Manage orders and product catalog with Dynamics 365

--- a/Instructions/Labs/03-2-Quotes.md
+++ b/Instructions/Labs/03-2-Quotes.md
@@ -2,7 +2,7 @@
 lab:
   title: 'Lab 3.2: Build quotes'
   description: As a sales analyst for the Dynamics 365 Sales implementation at Contoso Coffee, you want to ensure that salespeople will be able to leverage the product catalog enhancements throughout the entire sales lifecycle. To ensure the functionality is working correctly, you will test the process of building a quote from a new opportunity.
-  duration: 76 minutes
+  duration: 15 minutes
   level: 100
   islab: true
   primarytopics:

--- a/Instructions/Labs/03-2-Quotes.md
+++ b/Instructions/Labs/03-2-Quotes.md
@@ -1,6 +1,12 @@
 ---
 lab:
-    title: 'Lab 3.2: Build quotes'
+  title: 'Lab 3.2: Build quotes'
+  description: As a sales analyst for the Dynamics 365 Sales implementation at Contoso Coffee, you want to ensure that salespeople will be able to leverage the product catalog enhancements throughout the entire sales lifecycle. To ensure the functionality is working correctly, you will test the process of building a quote from a new opportunity.
+  duration: 76 minutes
+  level: 100
+  islab: true
+  primarytopics:
+    - Dynamics 365
 ---
 
 # Module 3: Manage orders and product catalog with Dynamics 365

--- a/Instructions/Labs/03-3-Orders-and-invoices.md
+++ b/Instructions/Labs/03-3-Orders-and-invoices.md
@@ -2,7 +2,7 @@
 lab:
   title: 'Lab 3.3: Orders and invoices'
   description: As a sales analyst for the Dynamics 365 Sales implementation at Contoso Coffee, you want to ensure that salespeople will be able to leverage the product catalog enhancements throughout the entire sales lifecycle. To ensure the functionality is working correctly, you will test the process of generating orders, and invoices.
-  duration: 54 minutes
+  duration: 15 minutes
   level: 100
   islab: true
   primarytopics:

--- a/Instructions/Labs/03-3-Orders-and-invoices.md
+++ b/Instructions/Labs/03-3-Orders-and-invoices.md
@@ -1,6 +1,12 @@
 ---
 lab:
-    title: 'Lab 3.3: Orders and invoices'
+  title: 'Lab 3.3: Orders and invoices'
+  description: As a sales analyst for the Dynamics 365 Sales implementation at Contoso Coffee, you want to ensure that salespeople will be able to leverage the product catalog enhancements throughout the entire sales lifecycle. To ensure the functionality is working correctly, you will test the process of generating orders, and invoices.
+  duration: 54 minutes
+  level: 100
+  islab: true
+  primarytopics:
+    - Dynamics 365
 ---
 
 # Module 3: Manage orders and product catalog with Dynamics 365

--- a/Instructions/Labs/05-1-Business-process-flow.md
+++ b/Instructions/Labs/05-1-Business-process-flow.md
@@ -2,7 +2,7 @@
 lab:
   title: 'Lab 5.1: Customize a business process flow'
   description: In this task, you will create a new Business Process Flow from the Opportunity Sales Process and then test the new BPF.
-  duration: 134 minutes
+  duration: 45 minutes
   level: 100
   islab: true
 ---

--- a/Instructions/Labs/05-1-Business-process-flow.md
+++ b/Instructions/Labs/05-1-Business-process-flow.md
@@ -1,6 +1,10 @@
 ---
 lab:
-    title: 'Lab 5.1: Customize a business process flow'
+  title: 'Lab 5.1: Customize a business process flow'
+  description: In this task, you will create a new Business Process Flow from the Opportunity Sales Process and then test the new BPF.
+  duration: 134 minutes
+  level: 100
+  islab: true
 ---
 
 # Module 5: Work with Dynamics 365 Sales Insights and the Sales accelerator 

--- a/Instructions/Labs/05-2-Sequences.md
+++ b/Instructions/Labs/05-2-Sequences.md
@@ -1,6 +1,10 @@
 ---
 lab:
-    title: 'Lab 5.2: Build a sequence'
+  title: 'Lab 5.2: Build a sequence'
+  description: 'Upon successful completion of this lab, you will be able to:'
+  duration: 154 minutes
+  level: 100
+  islab: true
 ---
 
 # Module 5: Work with Dynamics 365 Sales Insights and the Sales accelerator 

--- a/Instructions/Labs/05-2-Sequences.md
+++ b/Instructions/Labs/05-2-Sequences.md
@@ -2,7 +2,7 @@
 lab:
   title: 'Lab 5.2: Build a sequence'
   description: 'Upon successful completion of this lab, you will be able to:'
-  duration: 154 minutes
+  duration: 45 minutes
   level: 100
   islab: true
 ---

--- a/Instructions/Labs/06-1-Dashboard.md
+++ b/Instructions/Labs/06-1-Dashboard.md
@@ -2,7 +2,7 @@
 lab:
   title: 'Lab 6.1: Configure a dashboard'
   description: 'Upon successful completion of this lab, you will be able to:'
-  duration: 52 minutes
+  duration: 30 minutes
   level: 100
   islab: true
 ---

--- a/Instructions/Labs/06-1-Dashboard.md
+++ b/Instructions/Labs/06-1-Dashboard.md
@@ -1,6 +1,10 @@
 ---
 lab:
-    title: 'Lab 6.1: Configure a dashboard'
+  title: 'Lab 6.1: Configure a dashboard'
+  description: 'Upon successful completion of this lab, you will be able to:'
+  duration: 52 minutes
+  level: 100
+  islab: true
 ---
 
 # Module 6: Analyze Dynamics 365 Sales data


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 9

- `Instructions/Labs/00-Sales-trial.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/01-1-Configure-supporting-apps.md` (description,duration,level,islab)
- `Instructions/Labs/02-Manage-leads-opp.md` (description,duration,level,islab)
- `Instructions/Labs/03-1-Product-catalog.md` (description,duration,level,islab)
- `Instructions/Labs/03-2-Quotes.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/03-3-Orders-and-invoices.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/05-1-Business-process-flow.md` (description,duration,level,islab)
- `Instructions/Labs/05-2-Sequences.md` (description,duration,level,islab)
- `Instructions/Labs/06-1-Dashboard.md` (description,duration,level,islab)
