### PR TITLE
Update Lab 00 Task 1 steps for clarity and accuracy

### DIFF
--- a/Instructions/Labs/00-Sales-trial.md
+++ b/Instructions/Labs/00-Sales-trial.md
@@ -23,13 +23,18 @@ This lab will take approximately **10** minutes to complete.
 ### Exercise 1 – Access a trial environment
 
 #### Task 1 – Create a Trial
-1. In a new browser tab, navigate to https://dynamics.microsoft.com/dynamics-365-free-trial. In the middle of the screen, you will see two buttons: one to see plans and pricing, the other to try for free. Select **Try for free.**
-3. Locate Dynamic 365 Sales.
-4. Select the **Try for free** button.
-5. In the *Let's get started* screen, enter the credentials that were provided to you as part of your lab environment. Accept the license agreement. (If you are prompted to enter a phone number, you can enter 0123456789.)
-6. Select **Start your free trial**.
-7. (If prompted, select **Launch Trial** in the pop-up.
-8. Your trial will launch. It may take a few minutes for your environment to open.
-9. In the header, select **Sales trial.** This will open your list of available apps. In this course, we will be working mostly in the **Sales Hub.** Select **Sales Hub** to open the application.
-10. Feel free to take a few minutes to explore the application.
+1. Open a new browser and navigate to: https://dynamics.microsoft.com/dynamics-365-free-trial. 
+2. On the trial page, select **Try for free**.
+3. On the product listing page, locate **Dynamics 365 Sales** and select its **Try for free** button.
+4. In the *Let's get started* screen, enter the credentials that were provided to you as part of your lab environment and accept the license agreement.
+5. Select **Start your free trial**.
+6. Sign in with the **MOD administrator** credentials.
+7. If prompted to stay signed in, select yes.
+    > **Note:** If prompted to provide additional information, enter `0123456789` in the **Phone number** field and enter any value in the **Job title** field, then select **Submit**.
+8. If a pop-up dialog appears, select **Launch Trial**.
+9. Wait for the trial environment to finish provisioning. This may take several minutes.
+10. In the application header, select **Sales trial** to open the app switcher, then select **Sales Hub**.
+
+    > **Note:** The majority of lab exercises in this course are completed within **Sales Hub**.
+11. Feel free to take a few minutes to explore the application.
 


### PR DESCRIPTION
## Summary

This pull request updates the instructions for Lab 00 (Sales Trial) - Task 1: Create a Trial. The existing steps contained unclear directions and missing information that could confuse learners during the trial setup process. The revised instructions provide clearer, more accurate step-by-step guidance for creating a Dynamics 365 Sales trial environment.

## Changes

- Rewrote the trial creation steps to follow a clearer sequential flow (steps renumbered from 1 to 11)
- Separated the initial navigation and "Try for free" action into distinct steps for better clarity
- Added explicit step to sign in with MOD administrator credentials (step 6)
- Added step for the "Stay signed in" prompt (step 7)
- Added a Note block with specific guidance for the additional information prompt (phone number and job title fields)
- Clarified the "Launch Trial" step as conditional with proper formatting (step 8)
- Added explicit instruction to wait for the trial environment to finish provisioning (step 9)
- Improved the Sales Hub navigation step with clearer description of the app switcher (step 10)
- Added a Note block highlighting that most lab exercises are completed within Sales Hub
- Fixed formatting inconsistencies (e.g., removed parenthetical syntax, standardized bold/italic usage)

## Files changed

- `Instructions/Labs/00-Sales-trial.md`