### PR TITLE
Fix: Update and clarify Lab 3.2 (Quotes) instructions

### DIFF
--- a/Instructions/Labs/03-2-Quotes.md
+++ b/Instructions/Labs/03-2-Quotes.md
@@ -68,13 +68,13 @@ In this task, you will create a Quote from the Opportunity you created in Task 1
     > [!NOTE]
     > You can modify quantities and apply discounts to individual 
     > line items if needed.
-7. On the command bar, select **Activate Quote**.
+6. On the command bar, select **Activate Quote**.
     > [!NOTE]
     > Depending on your browser size, you may need to select the 
     > ellipsis (**⋮**) to find this option.
-8. On the command bar, select **Export to PDF**, then select **Print Quote for Customer**.
-9. Select **Download** and open the generated document to review 
+7. On the command bar, select **Export to PDF**, then select **Print Quote for Customer**.
+8. Select **Download** and open the generated document to review 
    the quote.
-10. Close the PDF.
-11. Close the **Export to PDF** window.
+9. Close the PDF.
+10. Close the **Export to PDF** window.
 

--- a/Instructions/Labs/03-2-Quotes.md
+++ b/Instructions/Labs/03-2-Quotes.md
@@ -34,7 +34,7 @@ In this task, you will create an Opportunity and add Products Line Items.
    - **Contact:** Jon Doe
 5. In the record header, select the **down arrow** next to the **Owner** field and select **Test Coffee Shop, Inc.** for **Account**, then select **Save**.
   > [!NOTE]
-    > If **Test Coffee Shop, Inc.** does not appear in the list, select **+ New** to create a new account, enter `Test Coffee Shop, Inc.` for **Account Name**, and select **Save & Close**.
+  > If **Test Coffee Shop, Inc.** does not appear in the list, select **+ New** to create a new account, enter `Test Coffee Shop, Inc.` for **Account Name**, and select **Save & Close**.
 6. Select the **Products** tab.
 7. Select the following values:
    - **Price List:** Filter Direct
@@ -49,21 +49,32 @@ In this task, you will create an Opportunity and add Products Line Items.
 11. Double click on the **Airpot XL 6 Month Filter** product.
 12. Locate the **Volume Discount** field and notice that no discount is applied.
 13. Change **Quantity** to `15` and select outside the field.
-  > [!NOTE]
-  > The discount is now applied and the **Volume Discount** field shows the discounted value.
+    > [!NOTE]
+    > The discount is now applied and the **Volume Discount** field shows the discounted value.
 14. Select **Save & Close.**
 
 #### Task 2 – Create Quote
 In this task, you will create a Quote from the Opportunity you created in Task 1.
-1. If not there already, go to your Dynamics 365 Sales Hub application.
-2. If necessary, open the opportunity you created in the previous task. It will be called **Interested in Airpot XL accessories.**
+1. If necessary, open the **Sales Hub** app and ensure you are in 
+   the **Sales** area.
+2. Open the **Interested in Airpot XL Accessories** opportunity.
 3. Select the **Quotes** tab.
-4. Above the subgrid, Click **+ New Quote.**
-5. The Quote form will open, and relevant information will be copied from the Opportunity.
-6. On the Interested in Airpot XL Accessories Quote page, examine the Products sub-grid and make sure products and their quantities look as you expected. You can change the quantities and discount the price of each line item.
-7. On the Command bar, select **Activate Quote.** (Depending on the size of your browser, you may need to select the ellipses to see this option.)
-8. Click **Export to PDF** located on the command bar and select **Print Quote for Customer.** Click **Download.**
-9. Open the generated document and see what the Quote looks like.
+4. Above the subgrid, select **+ New Quote.**
+    > [!NOTE]
+    > The quote form opens with relevant information copied from 
+    > the opportunity.
+5. Review the **Products** subgrid and verify that the products and 
+   quantities are correct.
+    > [!NOTE]
+    > You can modify quantities and apply discounts to individual 
+    > line items if needed.
+7. On the command bar, select **Activate Quote**.
+    > [!NOTE]
+    > Depending on your browser size, you may need to select the 
+    > ellipsis (**⋮**) to find this option.
+8. On the command bar, select **Export to PDF**, then select **Print Quote for Customer**.
+9. Select **Download** and open the generated document to review 
+   the quote.
 10. Close the PDF.
-11. Close the Export to PDF window.
+11. Close the **Export to PDF** window.
 

--- a/Instructions/Labs/03-2-Quotes.md
+++ b/Instructions/Labs/03-2-Quotes.md
@@ -30,7 +30,7 @@ In this task, you will create an Opportunity and add Products Line Items.
 2. In the left navigation, under **Sales** group, select **Opportunities**.
 3. Select **+ New.**
 4. Enter and select the following values:
-   - **Topic:** `Interested in Airpot XL Accessories`
+   - **Topic:** *Interested in Airpot XL Accessories*
    - **Contact:** Jon Doe
 5. In the record header, select the **down arrow** next to the **Owner** field and select **Test Coffee Shop, Inc.** for **Account**, then select **Save**.
   > [!NOTE]
@@ -42,9 +42,9 @@ In this task, you will create an Opportunity and add Products Line Items.
 8. Above the subgrid, select **+ Add products.**
 9. On the **Add products** panel, for each product, update the 
    **Quantity** and select **Add**:
-   - **Airpot XL 6 month filter** — Quantity: `6`
-   - **Airpot XL Pot Extender** — Quantity: `1`
-   - **Airpot XL Reservoir Extension** — Quantity: `1`
+   - **Airpot XL 6 month filter** — Quantity: *6*
+   - **Airpot XL Pot Extender** — Quantity: *1*
+   - **Airpot XL Reservoir Extension** — Quantity: *1*
 10. Select **Save to Opportunity**
 11. Double click on the **Airpot XL 6 Month Filter** product.
 12. Locate the **Volume Discount** field and notice that no discount is applied.

--- a/Instructions/Labs/03-2-Quotes.md
+++ b/Instructions/Labs/03-2-Quotes.md
@@ -27,22 +27,31 @@ This lab will take approximately **15** minutes to complete.
 #### Task 1 – Add Products Line Items
 In this task, you will create an Opportunity and add Products Line Items.
 1. Go to your Dynamics 365 Sales Hub application.
-2. From the left menu, in the Sales group, select **Opportunities.**
-3. Click **+ New.**
-4. Enter *Interested in Airpot XL Accessories* for Topic, and select **Jon Doe** for Contact.
-5. In the record header at the top select the **down arrow** next to the Owner field, and choose **Test Coffee Shop, Inc.** for Account. Select **Save.**
+2. In the left navigation, under **Sales** group, select **Opportunities**.
+3. Select **+ New.**
+4. Enter and select the following values:
+   - **Topic:** `Interested in Airpot XL Accessories`
+   - **Contact:** Jon Doe
+5. In the record header, select the **down arrow** next to the **Owner** field and select **Test Coffee Shop, Inc.** for **Account**, then select **Save**.
+  > [!NOTE]
+    > If **Test Coffee Shop, Inc.** does not appear in the list, select **+ New** to create a new account, enter `Test Coffee Shop, Inc.` for **Account Name**, and select **Save & Close**.
 6. Select the **Products** tab.
-7. You must select a Price List before you can add Opportunity Products. Select **Filter Direct** for Price List.
-8. Select **System Calculated** for Revenue.
-9. Above the subgrid, click **+ Add products.**
-10. From the All products list, find **Airpot XL 6 Month Filter**, enter *6* for Quantity, select **Add.**
-11. Find **AirpotXL pot extender** in the list of products, enter *1* for Quantity, and select **Add.**
-12. Find **Airpot XL Reservoir Extension** in the list of products, enter *1* for Quantity and select **Add.**
-13. You will see three products are added. Select **Save.**
-14. Double click on the **Airpot XL 6 Month Filter** product.
-15. Locate the Volume Discount field. You will find that there is no discount.
-16. Change the Quantity to *15* and click out of the field. The discount will now kick in and the Volume Discount field will show the discounted value.
-17. Select **Save & Close.**
+7. Select the following values:
+   - **Price List:** Filter Direct
+   - **Revenue:** System Calculated
+8. Above the subgrid, select **+ Add products.**
+9. On the **Add products** panel, for each product, update the 
+   **Quantity** and select **Add**:
+   - **Airpot XL 6 month filter** — Quantity: `6`
+   - **Airpot XL Pot Extender** — Quantity: `1`
+   - **Airpot XL Reservoir Extension** — Quantity: `1`
+10. Select **Save to Opportunity**
+11. Double click on the **Airpot XL 6 Month Filter** product.
+12. Locate the **Volume Discount** field and notice that no discount is applied.
+13. Change **Quantity** to `15` and select outside the field.
+  > [!NOTE]
+  > The discount is now applied and the **Volume Discount** field shows the discounted value.
+14. Select **Save & Close.**
 
 #### Task 2 – Create Quote
 In this task, you will create a Quote from the Opportunity you created in Task 1.


### PR DESCRIPTION
## Summary

This PR updates and clarifies the instructions for Lab 3.2 (Quotes) in the MB-280T02 course. The existing steps for both Task 1 (Add Products Line Items) and Task 2 (Create Quote) have been refined for improved clarity, consistency, and readability. Instructions now follow a more structured format with explicit field values, informational notes, and clearer step-by-step guidance.

## Changes

- **Task 1 – Add Products Line Items:**
   - Reformatted step 4 to list field values (Topic, Contact) in a structured format instead of inline text.
   - Consolidated Price List and Revenue selection into a single structured step (step 7).
   - Combined the three individual product addition steps into one consolidated step (step 9) with a bulleted list of products and quantities.
   - Changed action from "Save" to "Save to Opportunity" for accuracy.
   - Added `> [!NOTE]` blocks to highlight important information (e.g., creating Test Coffee Shop account, volume discount behavior).
   - Replaced vague descriptions (e.g., "click out of the field") with clearer instructions (e.g., "select outside the field").
   - Updated step numbering to reflect the consolidated steps (reduced from 17 to 14 steps).
- **Task 2 – Create Quote:**
   - Simplified the opening steps to be more concise and direct.
   - Added `> [!NOTE]` blocks for contextual information (quote form behavior, modifying quantities, finding the Activate Quote option).
   - Split the Export to PDF action into clearer sequential steps.
   - Reordered steps for a more logical flow.
   - Reduced step count from 11 to 10 by streamlining instructions.
## Files Changed

- `Instructions/Labs/03-2-Quotes.md` 