### PR TITLE
Fix: Refine Lab 3.3 instructions for Task 1 (Create Order) and Task 2 (Create Invoice)

### DIFF
--- a/Instructions/Labs/03-3-Orders-and-invoices.md
+++ b/Instructions/Labs/03-3-Orders-and-invoices.md
@@ -27,24 +27,36 @@ This lab will take approximately **15** minutes to complete.
 #### Task 1 – Create Order
 In this task, you will create an Order from a Quote.
 1. Go to your Dynamics 365 Sales Hub application.
-2. In the left menu, select **Quotes.**
-3. Open the Quote you created titled **Interested in Airpot XL Accessories.**
+2. In the left navigation, under **Collateral**, select **Quotes**.
+3. Open the **Interested in Airpot XL Accessories** quote.
    - Hint: Change the view to **My Quotes** to retrieve the quotes created.
 4. Select **Create Order.**
-5. Leave everything as default and click **OK.**
-6. The Order form will open. You can edit the Order information.
-7. Select the **vertical ellipsis button** at the end of the command bar. Select **Word Templates** and then select **Order Summary.**
-8. Open the generated Word document and review the Order. Close the Order Summary.
-9. At the end of the command bar, select **Fulfill Order.** (You may need to select the vertical ellipsis button.)
-10. Select **Fulfill.** The record will become read-only. Do not navigate away from this page.
+5. Leave everything as default and select **OK.**
+    > [!NOTE]
+    > The order form opens with relevant information
+    > You can edit the order information if needed.
+6. On the command bar, select the vertical ellipsis (**⋮**), select **Word Templates**, then select **Order Summary**.
+7. Open the generated Word document to review the order, then close the **Order Summary**.
+8. On the command bar, select **Fulfill Order**.
+    > [!NOTE]
+    > Depending on your browser size, you may need to select the 
+    > vertical ellipsis (**⋮**) to find this option.
+9. Select **Fulfill.**
+
+    > [!NOTE]
+    > The record becomes read-only after fulfillment. Do not 
+    > navigate away from this page.
 
 #### Task 2 – Create Invoice
 In this task, you will create an Invoice.
-1. Make sure you are still in the Order form.
-2. Select **Create Invoice** from the command bar.
-3. The Invoice form will open.
-4. Select the **vertical ellipsis button** at the end of the command bar. Select **Word Template** and then select **Invoice Summary.**
-5. Open the generated Word doc and review the Invoice. Close the Invoice Summary.
-6. We will assume the customer paid in full. Select **Invoice Paid.**
-7. Select **OK** to mark the invoice as complete.
+1. Make sure you are still in the **Order** form.
+2. On the command bar, select **Create Invoice**.
+    > [!NOTE]
+    > The invoice form opens with relevant information copied from 
+    > the order.
+3. On the command bar, select the vertical ellipsis (**⋮**), select 
+   **Word Templates**, then select **Invoice Summary**.
+4. Open the generated Word document to review the invoice, then close the **Invoice Summary**.
+5. On the command bar, select **Invoice Paid**.
+6. Select **OK** to mark the invoice as complete.
 


### PR DESCRIPTION
## Summary

This pull request improves the clarity and accuracy of the lab instructions for **Lab 3.3 – Orders and Invoices** (Module 03) in the MB-280T02 course. The existing steps for Task 1 (Create Order) and Task 2 (Create Invoice) contained ambiguous navigation guidance and lacked contextual notes for learners. This update refines the step-by-step instructions to be more precise, adds informational `[!NOTE]` callouts to guide students through UI-dependent behaviors, and standardizes the formatting across both tasks.

## Changes

- **Task 1 – Create Order:**
   - Updated Step 2 to clarify the navigation path: changed from "In the left menu, select Quotes" to "In the left navigation, under Collateral, select Quotes" for accuracy.
   - Refined Step 3 to use consistent bold formatting for the quote name.
   - Added a Hint for students to change the view to "My Quotes" to locate their created quotes.
   - Replaced "click" with "select" in Step 5 to align with Microsoft documentation standards.
   - Added `[!NOTE]` callout after Step 5 to inform learners that the order form opens with relevant information and can be edited.
   - Reworded Steps 6–8 to provide clearer guidance on using the vertical ellipsis (⋮) on the command bar for Word Templates and Fulfill Order actions.
   - Added `[!NOTE]` callouts to indicate browser size-dependent UI behavior and read-only record state after fulfillment.
   - Renumbered steps to reflect the updated flow (previously 10 steps, now 9 steps with added notes).
- **Task 2 – Create Invoice:**
   - Updated Step 1 to bold "Order" for emphasis and clarity.
   - Reworded Step 2 to specify "On the command bar" for consistency.
   - Added `[!NOTE]` callout explaining that the invoice form opens with information copied from the order.
   - Reworded Steps 3–5 for clarity, specifying the vertical ellipsis (⋮) usage and standardizing command bar references.
   - Reduced total steps from 7 to 6 by consolidating redundant instructions.
## Files Changed
`Instructions/Labs/03-3-Orders-and-invoices.md` 