### PR TITLE
Fix: Update Lab 5.1 instructions to align with current UI

### DIFF
--- a/Instructions/Labs/05-1-Business-process-flow.md
+++ b/Instructions/Labs/05-1-Business-process-flow.md
@@ -30,48 +30,60 @@ This lab will take approximately **45** minutes to complete.
 
 In this task, you will create a new Business Process Flow from the Opportunity Sales Process and then test the new BPF.
 
-1.  Navigate to [https://make.powerapps.com](https://make.powerapps.com/).
+1.  Navigate to `https://make.powerapps.com`
 2.  Ensure that you are in the **Sales Trial** environment.
 3.  Select **Solutions.**
-4.  On the command bar at the top, select the **+ New solution** button.
+4.  On the command bar at the top, select **+ New solution**.
 5.  In the **Display name** field, enter **Contoso**.
 6.  Select **+ New publisher**.
 7.  Configure the new publisher as follows.
     1.  **Display Name:** Contoso
     2.  **Name:** Contoso
-    3.  **Prefix:** Contoso
+    3.  **Prefix:** contoso
     4.  **Choice value prefix:** 10000
 8.  Select **Save**.
 9.  Under Publisher, select the new **Contoso** publisher that you just created.
 10. Select **Create**.
 11. On the **Command bar** select **Add** existing.
 12. From the menu that appears, select **Automation** \> **Process**.
-13. Now, we will find the **Sales Process** in the list of processes. (You can now use the search box in the upper right corner to search.) When you find it, select it.
+13. In the search box, enter `Sales Process` and select it from the results.
 14. Select the **Add** button.
 15. Select the **Sales Process** to open it.
-16. A new tab will open the BPF editor. (Keep the old tab with the Solutions list open.) Now, let's add the steps that our sellers have been requesting.
-17. First, we will add a condition to check the customer's budget and identify our potential high-value customers with budgets over \$1,000,000. Drag **Condition** from the **Components** tab and place it between the **Qualify** and **Develop** stages.
+16. A new tab opens the BPF editor. Keep the previous tab with the Solutions list open.
+17. From the **Components** tab, drag **Condition** and place it between the **Qualify** and **Develop** stages.
+    > [!NOTE]
+    > This condition checks the customer's budget and identifies 
+    > high-value customers with budgets over $1,000,000.
 18. Select the **Condition**, go to the **Properties** tab, and enter **Check Budget** for **Display Name**.
 19. Under **Rules,** select **Budget Amount** for **Field**.
 20. Select **Is Greater than or Equals to** for **Operator**.
 21. Select **Value** for **Type**.
-22. Enter **1,000,000** for **Value** and click **Apply**.
-23. Now we need to add a new stage to complete the condition. From the Components pane, add a new Stage to the right of the Condition.
+22. Enter **1,000,000** for **Value** and select **Apply**.
+23. From the **Components** pane, drag a new **Stage** and place it to the right of the **Condition**.
 24. Select the **Properties** tab.
 25. Enter **Confirm interest** for **Display Name**. Select **Apply.**
 26. Click the **Details** button of the **Confirm interest** stage.
 27. Select the **Data Step \#1 New Step** inside the **Confirm interest** stage.
-28. In the **Properties** tab, open the dropdown for **Data Field.** Select **Confirm interest**. The Step Name will update automatically.
+28. In the **Properties** tab, open the dropdown for **Data Field.** Select **Confirm interest**. 
+    > [!NOTE]
+    > The **Step Name** updates automatically.
 29. Check the **Required** check box and click **Apply**.
 30. Next, we will add a new step to ask for customer pain points in the Develop stage, as requested by our sellers. Select the **Develop** stage and expand **Details.**
 31. From the Components pane, drag a **Data Step** below Data Step \#4.
-32. In the Data Field drop down, select **Customer Pain Points.** It will now be a suggested step in the Develop stage to identify the customer pain points. We will not mark this field as required.
+32. In the Data Field drop down, select **Customer Pain Points.**
+    > [!NOTE]
+    > This step appears as a suggested step in the **Develop** stage 
+    > to identify customer pain points. This field is not marked as 
+    > required.
 33. Select **Apply.**
-34. Click **Validate** to ensure that the changes you made are valid and that the BPF will work as expected.
-35. If there are no issues, click **Update.**
+34. Select **Validate** to ensure that the changes you made are valid and that the BPF will work as expected.
+35. If there are no issues, select **Update.**
 36. Close the tab with the Business process flow editor.
-37. Back on your previous tab, click **Done** in the pop-up in the Default Solution area. In the top menu, select **Publish all customizations.** (You may need to delete the "opportunity" search in the text box in the upper right to be able to see this button.)
-38. Wait for your customizations to **publish**.
+37. Back on your previous tab, select **Done**.
+38. In the top menu, select **Publish all customizations.** 
+     > [!NOTE]
+     > You may need to delete the "opportunity" search in the text box in the upper right to be able to see this button.
+39. Wait for your customizations to **publish**.
 
 ### Task 2 – Test Business Process Flow
 

--- a/Instructions/Labs/05-1-Business-process-flow.md
+++ b/Instructions/Labs/05-1-Business-process-flow.md
@@ -30,7 +30,7 @@ This lab will take approximately **45** minutes to complete.
 
 In this task, you will create a new Business Process Flow from the Opportunity Sales Process and then test the new BPF.
 
-1.  Navigate to `https://make.powerapps.com`
+1.  Navigate to https://make.powerapps.com
 2.  Ensure that you are in the **Sales Trial** environment.
 3.  Select **Solutions.**
 4.  On the command bar at the top, select **+ New solution**.
@@ -77,7 +77,7 @@ In this task, you will create a new Business Process Flow from the Opportunity S
     > required.
 33. Select **Apply.**
 34. Select **Validate** to ensure that the changes you made are valid and that the BPF will work as expected.
-35. If there are no issues, select **Update.**
+35. If there are no issues, select **Update**.
 36. Close the tab with the Business process flow editor.
 37. Back on your previous tab, select **Done**.
 38. In the top menu, select **Publish all customizations.** 

--- a/Instructions/Labs/05-1-Business-process-flow.md
+++ b/Instructions/Labs/05-1-Business-process-flow.md
@@ -67,7 +67,7 @@ In this task, you will create a new Business Process Flow from the Opportunity S
 28. In the **Properties** tab, open the dropdown for **Data Field.** Select **Confirm interest**. 
     > [!NOTE]
     > The **Step Name** updates automatically.
-29. Check the **Required** check box and click **Apply**.
+29. Leave the **Required** checkbox unchecked, then select **Apply**.
 30. Next, we will add a new step to ask for customer pain points in the Develop stage, as requested by our sellers. Select the **Develop** stage and expand **Details.**
 31. From the Components pane, drag a **Data Step** below Data Step \#4.
 32. In the Data Field drop down, select **Customer Pain Points.**
@@ -88,18 +88,21 @@ In this task, you will create a new Business Process Flow from the Opportunity S
 ### Task 2 – Test Business Process Flow
 
 1.  Return to the Sales Hub app.
-2.  Navigate to the **Opportunities** section and click **+New** to create a new opportunity. Enter a topic such as **Interested in new machines**.
-3.  Select an existing contact for the contact field.
-4.  Open the **Qualify** stage of the Sales Process business process flow. Enter *\$800,000* for Estimated Budget.
-5.  The Business Process Flow should have 4 stages: **Qualify**, **Develop**, **Propose**, and **Close**. The Confirm Interest stage will not be part of the process if the Budget Amount is less than \$1,000,000.
-6.  Change the **Budget Amount** to *\$1,200,000.*
-7.  The Business Process Flow should now have 5 stages: **Qualify**, **Confirm Interest**, **Develop**, **Propose**, and **Close**. Move from the Qualify stage to the next stage.
+2.  In the left navigation, select **Opportunities**, then select **+ New** to create a new oppportunity.
+3.  In the **Topic** field, enter `Interested in new machines`.
+4.  In the **Contact** field, select an existing contact.
+5.  Open the **Qualify** stage of the Sales Process business process flow and enter *\$800,000* for Estimated Budget.
+    > [!NOTE] 
+    >The Business Process Flow includes 4 stages: **Qualify**, **Develop**, **Propose**, and **Close**. The Confirm Interest stage will not be part of the process if the Budget Amount is less than \$1,000,000.
+6.  Change the **Estimated budget amount** to *\$1,200,000.*
+7.  Confirm that the business process flow now shows five stages: **Qualify**, **Confirm Interest**, **Develop**, **Propose**, and **Close**.
 8.  **Save** The Opportunity.
-9.  Select the **Qualify** stage and select the **Next Stage** button to move to the **Confirm Interest** stage.
-10. Confirm interest by selecting **No,** then **Yes.**
-11. Select the **Next Stage** button to move to the **Develop** stage.
-12. Confirm that the Customer Pain Points field appears at the bottom of the Develop stage.
-13. Enter *Current machines cannot handle customer volume* in the Customer Pain Points field.
-14. Select **Next stage**.
-15. **Save** the record.
+9.  In the **Qualify** stage flyout, select **Next Stage** to advance to the **Confirm Interest** stage.
+10.  **Save** The Opportunity.
+11. In the **Confirm Interest** stage, for the **Confirmed Interest** field, select **No**, then select **Yes** to confirm.
+12. Select the **Next Stage** button to move to the **Develop** stage.
+13. Confirm that the Customer Pain Points field appears at the bottom of the Develop stage.
+14. Enter *Current machines cannot handle customer volume* in the Customer Pain Points field.
+15. Select **Next stage**.
+16. Select **Save** to save the record.
 

--- a/Instructions/Labs/05-1-Business-process-flow.md
+++ b/Instructions/Labs/05-1-Business-process-flow.md
@@ -98,7 +98,7 @@ In this task, you will create a new Business Process Flow from the Opportunity S
 7.  Confirm that the business process flow now shows five stages: **Qualify**, **Confirm Interest**, **Develop**, **Propose**, and **Close**.
 8.  **Save** The Opportunity.
 9.  In the **Qualify** stage flyout, select **Next Stage** to advance to the **Confirm Interest** stage.
-10.  **Save** The Opportunity.
+10. **Save** The Opportunity.
 11. In the **Confirm Interest** stage, for the **Confirmed Interest** field, select **No**, then select **Yes** to confirm.
 12. Select the **Next Stage** button to move to the **Develop** stage.
 13. Confirm that the Customer Pain Points field appears at the bottom of the Develop stage.


### PR DESCRIPTION
## Summary

This PR updates Lab 5.1 – Business Process Flow instructions to align with the current Dynamics 365 / Power Apps UI. It refines the wording for Exercise 1 – Task 1 and Task 2 and addresses an issue where, with Required checked on the Confirm Interest data step, the BPF fails to advance even though a valid value is present.
When Required is enabled, the Business Process Flow engine displays on the sales Hub the error “Confirm Interest: Required fields must be filled in” and prevents progression. This behavior persists despite multiple workaround attempts, including toggling values (No → Yes), saving the record, and refreshing the browser.
The update clarifies the instructions to avoid this blocker and standardizes action verbs and formatting throughout the lab for improved clarity and consistency.

## Changes

- **Task 1 – Exercise 1:** Replaced informal or outdated action verbs ("click", "Now, we will find…") with concise, UI-consistent language ("select", "drag", "enter").
   - **Step 10:** Fixed the `Prefix` value from `Contoso` to `contoso` (lowercase) to match the expected publisher prefix format.
   - **Step 13:** Replaced the vague instruction to find the Sales Process in a list with a clear direction to use the search box.
   - **Step 16:** Separated the editorial note from the step instruction and moved it to its own line for clarity.
   - **Step 22–23:** Changed "click Apply" to "select Apply" and reworded the stage-adding instruction to use "drag and place" instead of "add".
   - **Steps 28–29:** Split step 28 into two parts with a `NOTE` callout explaining the auto-update behavior. Changed step 29 from "Check the Required checkbox" to "Leave the Required checkbox unchecked" to match the intended lab behavior.
   - **Step 32:** Added a `NOTE` callout explaining the purpose of the Customer Pain Points step and that it is not marked as required.
   - **Steps 34–35:** Replaced "Click" with "Select" for Validate and Update actions.
   - **Steps 37–38:** Broke a long combined step into two separate steps and moved the search-box tip into a `NOTE` callout.
 - **Task 2:** Rewrote steps 2–16 to match the current Sales Hub navigation and UI flow, including explicit field names, updated step ordering, and added `NOTE` callouts for expected BPF stage behavior.
## Files changed

- `Instructions/Labs/05-1-Business-process-flow.md` 